### PR TITLE
README: add doc title & PCD link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# RDD 59-1
-Public CD of SMPTE RDD 59-1
+# RDD 59-1 - Interoperable Master Format - Application DPP (ProRes)
+[Public Committee Draft (PCD)](https://www.smpte.org/public-committee-drafts) of SMPTE RDD 59-1
 
 [GitHub issues](https://github.com/SMPTE/rdd59-1/issues) are preferred for discussion of this specification. Alternatively, comments can be sent to 35pm-chair@smpte.org.
 


### PR DESCRIPTION
I've received feedback that these small changes would help those outside SMPTE who are accessing this repo.

Including the title in the heading is per the [SMPTE IEEE Standards store](https://ieeexplore.ieee.org/browse/standards/number/smpte).

I realise the PCD repos follow a template -- perhaps these adjustments would be useful across all such repos?